### PR TITLE
[PA-16] - Configuring circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,22 +19,30 @@ jobs:
   build:
     executor: base-executor
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
       - checkout
       - run: git submodule sync
       - run: git submodule init
       - run: git submodule update --recursive
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+      - restore_cache:  # ensure this step occurs *before* installing dependencies
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
             sudo pip install pipenv
             pipenv install
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - ".venv"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.7/site-packages"
   py-linter:
     executor: base-executor
     steps:
       - checkout
+      - restore_cache:  # ensure this step occurs *before* installing dependencies
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Run python code linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv
-            pipenv install
+            pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
@@ -37,7 +37,7 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv
-            pipenv install
+            pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             sudo pip install pipenv
             touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
-            pipenv install --skip-lock
+            pipenv install --dev --skip-lock
       - save_cache:
           key: buildpipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
@@ -41,7 +41,7 @@ jobs:
             sudo pip install pipenv
             touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
-            pipenv install --skip-lock
+            pipenv install --dev --skip-lock
       - save_cache:
           key: pylinter-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv
+            touch /home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
+            touch /home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
@@ -37,6 +39,8 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv
+            touch /home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
+            touch /home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,15 +6,6 @@ executors:
     docker:
       - image: circleci/python:3.7.3
 
-commands:
-  verify_docker_works:
-    description: Verify docker works
-    steps:
-      - run:
-          name: Verify Docker Works
-          command: |
-            docker --version
-
 jobs:
   build:
     executor: base-executor
@@ -43,6 +34,16 @@ jobs:
       - checkout
       - restore_cache:  # ensure this step occurs *before* installing dependencies
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+      - run:
+          command: |
+            sudo pip install pipenv
+            pipenv install
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - ".venv"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.7/site-packages"
       - run:
           name: Run python code linter
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv
+            mkdir -p /home/pi/wheels
             touch /home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch /home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock
@@ -38,7 +39,8 @@ jobs:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
-            sudo pip install pipenv
+            sudo pip install pipenv\
+            mkdir -p /home/pi/wheels
             touch /home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch /home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: buildpipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: buildpipenv-v2-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
             sudo pip install pipenv
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: pylinter-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pylinter-v2-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
             sudo pip install pipenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,16 +17,15 @@ jobs:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: buildpipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
             sudo pip install pipenv
             touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
-            python -c "import platform; print(platform.release())"
             pipenv install --skip-lock
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: buildpipenv-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
             - "/usr/local/bin"
@@ -36,7 +35,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pylinter-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
             sudo pip install pipenv
@@ -44,7 +43,7 @@ jobs:
             touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pylinter-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
             - ".venv"
             - "/usr/local/bin"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             sudo pip install pipenv
             touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
+            python -c "import platform; print(platform.release())"
             pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
@@ -38,7 +39,7 @@ jobs:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
-            sudo pip install pipenv\
+            sudo pip install pipenv
             touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
             touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,58 +16,43 @@ commands:
             docker --version
 
 jobs:
-  run-build-tests:
+  build:
     executor: base-executor
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout
-      - verify_docker_works
       - run: git submodule sync
       - run: git submodule init
       - run: git submodule update --recursive
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+      - restore_cache:  # ensure this step occurs *before* installing dependencies
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
-          name: build CPU image
           command: |
-            docker build --target peoples-anthem  -t pa-image:cpu .
-            docker create -v /app --name pa_app pa-image:cpu /bin/true
-            docker cp ./ pa_app:/app
-  # docker run --rm -it --volumes-from pa_app --entrypoint bash pa-image:cpu -c 'pytest ./tests'
+            sudo pip install pipenv
+            pipenv install
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - ".venv"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.7/site-packages"
   py-linter:
     executor: base-executor
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: false
       - checkout
-      - verify_docker_works
+      - restore_cache:  # ensure this step occurs *before* installing dependencies
+          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Run python code linter
           command: |
-            docker create -v /apps --name pa_app alpine/flake8:3.7.3 /bin/true
-            docker cp ./ pa_app:/apps
-            MODIFIED_PY_FILES=$(git diff --name-only --diff-filter=ACMTUXB origin/master...${CIRCLE_BRANCH} -- '*.py')
-            if [ "$MODIFIED_PY_FILES" != "" ]; then
-                echo "Running Flake8..."
-                declare -a arr=($MODIFIED_PY_FILES)
-                for i in "${arr[@]}"
-                do
-                    echo "checking $i"
-                    if cat "$i" | grep "^# jupyter:$" && cat "$i" |grep "^#   jupytext:$"; then
-                        echo "jupytext file, skipping!"
-                        continue
-                    fi
-                    if ! [ -x "$(command -v flake8)" ]; then
-                        docker run --rm -t -v $(pwd):/apps alpine/flake8:3.7.3  --max-line-length=120 --ignore=E731,W503,W504,E203 "$i"
-                    else
-                        flake8 --max-line-length=120 --ignore=E731,W503,W504,E203 "$i"
-                    fi
-                done
-                echo "completed!"
-            fi
+            make check-format
 
 workflows:
   version: 2.1
   build-and-test:
     jobs:
-      - run-build-tests
+      - build
       - py-linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,8 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv
-            mkdir -p /home/pi/wheels
-            touch /home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
-            touch /home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
+            touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
+            touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
@@ -40,9 +39,8 @@ jobs:
       - run:
           command: |
             sudo pip install pipenv\
-            mkdir -p /home/pi/wheels
-            touch /home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
-            touch /home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
+            touch ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
+            touch ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
             pipenv install --skip-lock
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,24 +27,14 @@ jobs:
       - run: git submodule update --recursive
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
-      - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
             sudo pip install pipenv
             pipenv install
-      - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - ".venv"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.7/site-packages"
   py-linter:
     executor: base-executor
     steps:
       - checkout
-      - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Run python code linter
           command: |

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,7 @@ __pycache__
 *.parquet
 *.zip
 *.txt
+*.whl
 
 # MODELS
 */models/*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.parquet
 *.zip
 *.txt
+*.whl
 
 # MODELS
 */models/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,11 +107,11 @@ ENV XDG_CACHE_HOME=/torch_models/.cache
 # Downloading haarcascade face detection .xml
 # Downloading torch and torchvision .whl compiled for pi4
 RUN mkdir --parents /home/${USER}/models-cache/face-cascade && \
-    mkdir --parents /home/${USER}/wheels && \
+    mkdir --parents ./whl && \
     mkdir --parents ${XDG_CACHE_HOME}/torch/checkpoints && \
     wget https://github.com/opencv/opencv/raw/master/data/haarcascades/haarcascade_frontalface_default.xml -O /home/${USER}/models-cache/face-cascade/haarcascade_frontalface_default.xml && \
-    wget https://www.dropbox.com/s/015k4qyoofi6ld5/torch-1.6.0a0%2Bb31f58d-cp37-cp37m-linux_armv7l.whl?dl=0 -O /home/${USER}/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl && \
-    wget https://www.dropbox.com/s/mmm5b0ovehujfz0/torchvision-0.7.0a0%2B78ed10c-cp37-cp37m-linux_armv7l.whl?dl=0 -O /home/${USER}/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl && \
+    wget https://www.dropbox.com/s/015k4qyoofi6ld5/torch-1.6.0a0%2Bb31f58d-cp37-cp37m-linux_armv7l.whl?dl=0 -O ./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl && \
+    wget https://www.dropbox.com/s/mmm5b0ovehujfz0/torchvision-0.7.0a0%2B78ed10c-cp37-cp37m-linux_armv7l.whl?dl=0 -O ./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl && \
     wget https://github.com/timesler/facenet-pytorch/releases/download/v2.2.9/20180402-114759-vggface2.pt -O ${XDG_CACHE_HOME}/torch/checkpoints/20180402-114759-vggface2.pt
 
 COPY Pipfile Pipfile.lock .

--- a/Pipfile
+++ b/Pipfile
@@ -15,8 +15,8 @@ cython = "==0.29.21"
 numpy = "==1.19.3"
 picamerab = {version = "==1.13b1", platform_release = "== '5.4.83-v7l+'"}
 pillow = "==8.0.1"
-torch = {path = "/home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
-torchvision = {path = "/home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
+torch = {path = "./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
+torchvision = {path = "./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
 scikit-build = "==0.11.1"
 pip = "*"
 opencv-contrib-python = {file = "https://www.piwheels.org/simple/opencv-contrib-python/opencv_contrib_python-4.1.0.25-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}

--- a/Pipfile
+++ b/Pipfile
@@ -13,13 +13,13 @@ pytest = "==6.2.4"
 [packages]
 cython = "==0.29.21"
 numpy = "==1.19.3"
-picamerab = "==1.13b1"
+picamerab = {version = "==1.13b1", platform_release = "== '5.4.83-v7l+'"}
 pillow = "==8.0.1"
-torch = {path = "/home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl"}
-torchvision = {path = "/home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl"}
+torch = {path = "/home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
+torchvision = {path = "/home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
 scikit-build = "==0.11.1"
 pip = "*"
-opencv-contrib-python = {file = "https://www.piwheels.org/simple/opencv-contrib-python/opencv_contrib_python-4.1.0.25-cp37-cp37m-linux_armv7l.whl"}
+opencv-contrib-python = {file = "https://www.piwheels.org/simple/opencv-contrib-python/opencv_contrib_python-4.1.0.25-cp37-cp37m-linux_armv7l.whl", platform_release = "== '5.4.83-v7l+'"}
 tqdm = "==4.51.0"
 python-vlc = "==3.0.11115"
 spotipy = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7e504ddc02efc5188b84c273859d3cc52d83db8ab4fe8ffe056a689e1c8a66f1"
+            "sha256": "2bad6ccd0e632054224a154a95949fdf08083ff597ef8da431df2b11063f89eb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -452,7 +452,7 @@
                 "sha256:1665c41422121326c592d5590d9516d1c4dc7cbde58154cb1532332cab162c6b"
             ],
             "markers": "platform_release == '5.4.83-v7l+'",
-            "path": "/home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl",
+            "path": "./whl/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl",
             "version": "==1.6.0a0+b31f58d"
         },
         "torchvision": {
@@ -460,7 +460,7 @@
                 "sha256:5c5e3bf404a1491f207d5767df8edc8c2095837a662ae23fccee64b4e52a4b86"
             ],
             "markers": "platform_release == '5.4.83-v7l+'",
-            "path": "/home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl",
+            "path": "./whl/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl",
             "version": "==0.7.0a0+78ed10c"
         },
         "tqdm": {
@@ -657,11 +657,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:960d52ba7c21377c990412aca380bf3642d734c2eaab78a2c39319f67c6a5786",
-                "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"
+                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
+                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
             ],
             "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==4.4.0"
+            "version": "==4.5.0"
         },
         "iniconfig": {
             "hashes": [
@@ -680,11 +680,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:a171caa3d3d4c819a1c0742e3abecfd5a2b8ab525ca1c9f114b40b76b0679ab1",
-                "sha256:f86788eef439891438af3498525094cc2acbdbea4f2aa2f8895782d4ff471341"
+                "sha256:9bc24a99f5d19721fb8a2d1408908e9c0520a17fff2233ffe82620847f17f1b6",
+                "sha256:d513e93327cf8657d6467c81f1f894adc125334ffe0e4ddd1abbb1c78d828703"
             ],
             "markers": "python_version >= '3.3'",
-            "version": "==7.24.0"
+            "version": "==7.24.1"
         },
         "ipython-genutils": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0e4e2ecba6560cc4697d4978c8d6b50782a8f9fa719120593be5d5647983e717"
+            "sha256": "7e504ddc02efc5188b84c273859d3cc52d83db8ab4fe8ffe056a689e1c8a66f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.5.30"
         },
         "chardet": {
             "hashes": [
@@ -204,6 +204,7 @@
                 "sha256:f5bec4ab094958488d25d7ebbb805b8ee49cd58a6ed0983d13fffa0dcb5276f6"
             ],
             "index": "pypi",
+            "markers": "platform_release == '5.4.83-v7l+'",
             "version": "==4.1.0.25"
         },
         "packaging": {
@@ -250,6 +251,7 @@
                 "sha256:595cd46a1aeb1f8b364a5c8b545febb157473051f0af5692534f88c6d7d8c708"
             ],
             "index": "pypi",
+            "markers": "platform_release == '5.4.83-v7l+'",
             "version": "==1.13b1"
         },
         "pillow": {
@@ -449,6 +451,7 @@
             "hashes": [
                 "sha256:1665c41422121326c592d5590d9516d1c4dc7cbde58154cb1532332cab162c6b"
             ],
+            "markers": "platform_release == '5.4.83-v7l+'",
             "path": "/home/pi/wheels/torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl",
             "version": "==1.6.0a0+b31f58d"
         },
@@ -456,6 +459,7 @@
             "hashes": [
                 "sha256:5c5e3bf404a1491f207d5767df8edc8c2095837a662ae23fccee64b4e52a4b86"
             ],
+            "markers": "platform_release == '5.4.83-v7l+'",
             "path": "/home/pi/wheels/torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl",
             "version": "==0.7.0a0+78ed10c"
         },
@@ -653,11 +657,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2d932ea08814f745863fd20172fe7de4794ad74567db78f2377343e24520a5b6",
-                "sha256:c2e27fa8b6c8b34ebfcd4056ae2ca290e36250d1fbeceec85c1c67c711449fac"
+                "sha256:960d52ba7c21377c990412aca380bf3642d734c2eaab78a2c39319f67c6a5786",
+                "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"
             ],
             "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==4.3.1"
+            "version": "==4.4.0"
         },
         "iniconfig": {
             "hashes": [
@@ -931,11 +935,11 @@
         },
         "prometheus-client": {
             "hashes": [
-                "sha256:030e4f9df5f53db2292eec37c6255957eb76168c6f974e4176c711cf91ed34aa",
-                "sha256:b6c5a9643e3545bcbfd9451766cbaa5d9c67e7303c7bc32c750b6fa70ecb107d"
+                "sha256:3a8baade6cb80bcfe43297e33e7623f3118d660d41387593758e2fb1ea173a86",
+                "sha256:b014bc76815eb1399da8ce5fc84b7717a3e63652b0c0f8804092c9363acab1b2"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.1"
+            "version": "==0.11.0"
         },
         "prompt-toolkit": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # People's Anthem
-
 ![peoples-anthem-logo](./assets/logo.png "People's anthem")
+
+[![alexantoinefortin](https://circleci.com/gh/alexantoinefortin/peoples-anthem.svg?style=shield)](https://app.circleci.com/pipelines/github/alexantoinefortin/peoples-anthem)
 
 A project using facial recognition and a raspberry pi's camera to identify a person and play their favorite music.
 

--- a/whl/README.md
+++ b/whl/README.md
@@ -1,0 +1,11 @@
+# whl
+In this section of the repo, we put scripts used to build `torch` and `torchvision` wheel file on `rpi4`.
+This is also the directory where these `.whl` must be kept after they are built.
+
+## Notes
+The wheels can be downloaded like so:
+
+```bash
+wget https://www.dropbox.com/s/015k4qyoofi6ld5/torch-1.6.0a0%2Bb31f58d-cp37-cp37m-linux_armv7l.whl?dl=0 -O ./torch-1.6.0a0+b31f58d-cp37-cp37m-linux_armv7l.whl
+wget https://www.dropbox.com/s/mmm5b0ovehujfz0/torchvision-0.7.0a0%2B78ed10c-cp37-cp37m-linux_armv7l.whl?dl=0 -O ./torchvision-0.7.0a0+78ed10c-cp37-cp37m-linux_armv7l.whl
+```

--- a/whl/get_torch_whl.sh
+++ b/whl/get_torch_whl.sh
@@ -1,0 +1,16 @@
+git clone https://github.com/pytorch/pytorch --recursive && cd pytorch
+cd pytorch
+git checkout v1.6.0 # optional, you can build master if you are brave
+git submodule update --init --recursive
+
+
+export NO_CUDA=1
+export NO_DISTRIBUTED=1
+export NO_MKLDNN=1 
+export BUILD_TEST=0 # for faster builds
+export MAX_JOBS=3
+# export NO_NNPACK=1
+# export NO_QNNPACK=1
+
+python3 setup.py bdist_wheel
+

--- a/whl/get_torchvision_whl.sh
+++ b/whl/get_torchvision_whl.sh
@@ -1,0 +1,13 @@
+git clone https://github.com/pytorch/vision && cd vision
+git checkout v0.7.0
+git submodule update --init --recursive
+
+export NO_CUDA=1
+export NO_DISTRIBUTED=1
+export NO_MKLDNN=1 
+export BUILD_TEST=0 # for faster builds
+export MAX_JOBS=3
+# export NO_NNPACK=1
+# export NO_QNNPACK=1
+
+python3 setup.py bdist_wheel


### PR DESCRIPTION
**Related issue**
resolves #16 

**Notes**
* Will improve tests coverage in future PR and will add will run pytest` in `.circleci/config.yml`
* Will need to add alternative dependencies for `torch` and `torchvision` when `pipenv install --dev --skip-lock` on `circleci`
 
**What's new in this PR?**
* Adding `circleci` badge to `README.md`
* Adding `.circleci/config.yml` with 2 phases:
  * build
  * pylinter
* Adding script to build `torch` and `torchvision` `.whl`
* Modified dependencies in `Pipfile` so that raspberry pi specific dependencies are only installed on rpi
